### PR TITLE
Make gem configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    better_rate_limit (0.1.5)
+    better_rate_limit (0.1.6)
       actionpack (>= 5.0)
       redis (>= 3.3)
 
@@ -59,7 +59,7 @@ GEM
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rake (12.3.3)
-    redis (4.2.5)
+    redis (4.3.1)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tzinfo (1.2.7)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ ActiveSupport::Notifications.subscribe /rate_limit/ do |_name, _start, _finish, 
 end
 ```
 
+### Configuration
+You can ignore the throttle by using the following configuration
+```ruby
+BetterRateLimit.configure do |config|
+  config.ignore = true
+end
+```
+Useful to ignore the throttle on tests.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/better_rate_limit.rb
+++ b/lib/better_rate_limit.rb
@@ -1,4 +1,21 @@
 require 'action_controller'
+require 'better_rate_limit/configuration'
+
+module BetterRateLimit
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield configuration
+    end
+
+    def reset_configuration
+      @configuration = Configuration.new
+    end
+  end
+end
 
 module ActionController
   autoload :BetterRateLimit, 'action_controller/better_rate_limit'

--- a/lib/better_rate_limit/configuration.rb
+++ b/lib/better_rate_limit/configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BetterRateLimit
+  class Configuration
+    attr_accessor :ignore
+
+    def initialize
+      @ignore = false
+    end
+  end
+end

--- a/lib/better_rate_limit/throttle.rb
+++ b/lib/better_rate_limit/throttle.rb
@@ -10,6 +10,8 @@ module BetterRateLimit
 
     class << self
       def throttle(key, limit:, time_window:)
+        return true if BetterRateLimit.configuration.ignore
+
         now = Time.now.utc
         timestamps_count = redis_client.llen key
 

--- a/lib/better_rate_limit/version.rb
+++ b/lib/better_rate_limit/version.rb
@@ -1,3 +1,3 @@
 module BetterRateLimit
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/test/better_rate_limit/configuration_test.rb
+++ b/test/better_rate_limit/configuration_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ConfigurationTest < Minitest::Test
+  def test_default_configuration
+    assert_equal false, BetterRateLimit::Configuration.new.ignore
+  end
+
+  def test_configuration_ignore_option
+    configuration = BetterRateLimit::Configuration.new
+    configuration.ignore = true
+
+    assert_equal true, configuration.ignore
+  end
+end

--- a/test/better_rate_limit/throttle_test.rb
+++ b/test/better_rate_limit/throttle_test.rb
@@ -17,6 +17,16 @@ class ThrottleTest < Minitest::Test
     Timecop.return
   end
 
+  def test_do_not_throttle_if_ignore_is_set
+    BetterRateLimit.configure do |config|
+      config.ignore = true
+    end
+
+    assert_equal true, @subject.throttle('foo', limit: 2, time_window: 1.hour)
+
+    BetterRateLimit.reset_configuration
+  end
+
   def test_adds_current_timestamp_to_redis_list
     key = 'foo'
     timestamps_list = -> { @redis.lrange key, 0, -1 }

--- a/test/better_rate_limit_test.rb
+++ b/test/better_rate_limit_test.rb
@@ -6,4 +6,24 @@ class BetterRateLimitTest < ActiveSupport::TestCase
   test 'version' do
     assert_not_equal nil, BetterRateLimit::VERSION
   end
+
+  test 'configuration' do
+    BetterRateLimit.configure do |config|
+      config.ignore = true
+    end
+
+    assert_equal true, BetterRateLimit.configuration.ignore
+  end
+
+  test 'reset configuration' do
+    BetterRateLimit.configure do |config|
+      config.ignore = true
+    end
+
+    assert_equal true, BetterRateLimit.configuration.ignore
+
+    BetterRateLimit.reset_configuration
+
+    assert_equal false, BetterRateLimit.configuration.ignore
+  end
 end


### PR DESCRIPTION
This is going to be useful to ignore the throttle on tests.

``` ruby
BetterRateLimit.configure do |config|
  config.ignore = Rails.env.testing?
end
```

Closes https://github.com/upscopeio/better_rate_limit/issues/8